### PR TITLE
Skeleton form builder

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -8,3 +8,6 @@ require: rubocop-rake
 AllCops:
   TargetRubyVersion: 3.0
   SuggestExtensions: false
+
+RSpec/MultipleExpectations:
+  Enabled: false

--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,8 @@ source "https://rubygems.org"
 gemspec
 
 gem "citizens-advice-style", github: "citizensadvice/citizens-advice-style-ruby", tag: "v10.0.1"
+gem "nokogiri"
+gem "pry"
 gem "rake", "~> 13.0"
 gem "rspec", "~> 3.0"
 gem "rubocop-rake"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -12,10 +12,31 @@ PATH
   remote: .
   specs:
     citizens_advice_form_builder (0.1.0)
+      actionpack (>= 7.0)
+      actionview (>= 7.0)
+      activemodel (>= 7.0)
+      activesupport (>= 7.0)
 
 GEM
   remote: https://rubygems.org/
   specs:
+    actionpack (7.1.1)
+      actionview (= 7.1.1)
+      activesupport (= 7.1.1)
+      nokogiri (>= 1.8.5)
+      rack (>= 2.2.4)
+      rack-session (>= 1.0.1)
+      rack-test (>= 0.6.3)
+      rails-dom-testing (~> 2.2)
+      rails-html-sanitizer (~> 1.6)
+    actionview (7.1.1)
+      activesupport (= 7.1.1)
+      builder (~> 3.1)
+      erubi (~> 1.11)
+      rails-dom-testing (~> 2.2)
+      rails-html-sanitizer (~> 1.6)
+    activemodel (7.1.1)
+      activesupport (= 7.1.1)
     activesupport (7.1.1)
       base64
       bigdecimal
@@ -29,23 +50,49 @@ GEM
     ast (2.4.2)
     base64 (0.1.1)
     bigdecimal (3.1.4)
+    builder (3.2.4)
+    coderay (1.1.3)
     concurrent-ruby (1.2.2)
     connection_pool (2.4.1)
+    crass (1.0.6)
     diff-lcs (1.5.0)
     drb (2.1.1)
       ruby2_keywords
+    erubi (1.12.0)
     i18n (1.14.1)
       concurrent-ruby (~> 1.0)
     json (2.6.3)
     language_server-protocol (3.17.0.3)
+    loofah (2.22.0)
+      crass (~> 1.0.2)
+      nokogiri (>= 1.12.0)
+    method_source (1.0.0)
     minitest (5.20.0)
     mutex_m (0.1.2)
+    nokogiri (1.15.5-arm64-darwin)
+      racc (~> 1.4)
+    nokogiri (1.15.5-x86_64-linux)
+      racc (~> 1.4)
     parallel (1.23.0)
     parser (3.2.2.4)
       ast (~> 2.4.1)
       racc
+    pry (0.14.2)
+      coderay (~> 1.1)
+      method_source (~> 1.0)
     racc (1.7.1)
     rack (3.0.8)
+    rack-session (2.0.0)
+      rack (>= 3.0.0)
+    rack-test (2.1.0)
+      rack (>= 1.3)
+    rails-dom-testing (2.2.0)
+      activesupport (>= 5.0.0)
+      minitest
+      nokogiri (>= 1.6)
+    rails-html-sanitizer (1.6.0)
+      loofah (~> 2.21)
+      nokogiri (~> 1.14)
     rainbow (3.1.1)
     rake (13.0.6)
     regexp_parser (2.8.2)
@@ -104,6 +151,8 @@ PLATFORMS
 DEPENDENCIES
   citizens-advice-style!
   citizens_advice_form_builder!
+  nokogiri
+  pry
   rake (~> 13.0)
   rspec (~> 3.0)
   rubocop-rake

--- a/citizens_advice_form_builder.gemspec
+++ b/citizens_advice_form_builder.gemspec
@@ -29,6 +29,8 @@ Gem::Specification.new do |spec|
   spec.executables = spec.files.grep(%r{\Aexe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  # Uncomment to register a new dependency of your gem
-  # spec.add_dependency "example-gem", "~> 1.0"
+  spec.add_dependency "actionpack", ">= 7.0"
+  spec.add_dependency "actionview", ">= 7.0"
+  spec.add_dependency "activemodel", ">= 7.0"
+  spec.add_dependency "activesupport", ">= 7.0"
 end

--- a/lib/citizens_advice_form_builder.rb
+++ b/lib/citizens_advice_form_builder.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
+require_relative "citizens_advice_form_builder/form_builder"
 require_relative "citizens_advice_form_builder/version"
 
 module CitizensAdviceFormBuilder
   class Error < StandardError; end
-  # Your code goes here...
 end

--- a/lib/citizens_advice_form_builder/form_builder.rb
+++ b/lib/citizens_advice_form_builder/form_builder.rb
@@ -4,14 +4,16 @@ require "action_view"
 
 module CitizensAdviceFormBuilder
   class FormBuilder < ActionView::Helpers::FormBuilder
-    def cads_text_field(attribute)
+    def cads_text_field(attribute, label: nil)
+      label_text = label
+
       @template.content_tag(:fieldset) do
-        label(attribute) + text_field(attribute)
+        label(attribute, label_text) + text_field(attribute)
       end
     end
 
-    def cads_button
-      @template.submit_tag
+    def cads_button(value = "Save changes")
+      @template.submit_tag(value)
     end
   end
 end

--- a/lib/citizens_advice_form_builder/form_builder.rb
+++ b/lib/citizens_advice_form_builder/form_builder.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require "action_view"
+
+module CitizensAdviceFormBuilder
+  class FormBuilder < ActionView::Helpers::FormBuilder
+    def cads_text_field(attribute)
+      @template.content_tag(:fieldset) do
+        label(attribute) + text_field(attribute)
+      end
+    end
+
+    def cads_button
+      @template.submit_tag
+    end
+  end
+end

--- a/spec/citizens_advice_form_builder/form_builder_spec.rb
+++ b/spec/citizens_advice_form_builder/form_builder_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+class ExampleForm
+  include ActiveModel::Model
+
+  attr_accessor :name
+end
+
+RSpec.describe CitizensAdviceFormBuilder::FormBuilder do
+  let(:controller) { ActionController::Base.new }
+  let(:lookup_context) { ActionView::LookupContext.new(nil) }
+  let(:helper) { ActionView::Base.new(lookup_context, {}, controller) }
+  let(:object) { ExampleForm.new(name: "Fred Flintstone") }
+  let(:builder) { described_class.new(:example_form, object, helper, {}) }
+
+  describe "#cads_button" do
+    it "renders a submit button" do
+      result = builder.cads_button
+      parsed_result = Nokogiri::HTML::DocumentFragment.parse(result)
+
+      expect(parsed_result.at_css("input").attributes["value"].value).to eq "Save changes"
+    end
+  end
+
+  describe "#cads_text_field" do
+    it "renders a text field" do
+      result = builder.cads_text_field(:name)
+      parsed_result = Nokogiri::HTML::DocumentFragment.parse(result)
+
+      expect(parsed_result.at_css("input").attributes["value"].value).to eq "Fred Flintstone"
+    end
+  end
+end

--- a/spec/citizens_advice_form_builder/form_builder_spec.rb
+++ b/spec/citizens_advice_form_builder/form_builder_spec.rb
@@ -20,6 +20,13 @@ RSpec.describe CitizensAdviceFormBuilder::FormBuilder do
 
       expect(parsed_result.at_css("input").attributes["value"].value).to eq "Save changes"
     end
+
+    it "renders a submit button with a custom label" do
+      result = builder.cads_button("Next")
+      parsed_result = Nokogiri::HTML::DocumentFragment.parse(result)
+
+      expect(parsed_result.at_css("input").attributes["value"].value).to eq "Next"
+    end
   end
 
   describe "#cads_text_field" do
@@ -27,7 +34,15 @@ RSpec.describe CitizensAdviceFormBuilder::FormBuilder do
       result = builder.cads_text_field(:name)
       parsed_result = Nokogiri::HTML::DocumentFragment.parse(result)
 
+      expect(parsed_result.at_css("label").content).to eq "Name"
       expect(parsed_result.at_css("input").attributes["value"].value).to eq "Fred Flintstone"
+    end
+
+    it "renders a text field with a custom label" do
+      result = builder.cads_text_field(:name, label: "First name")
+      parsed_result = Nokogiri::HTML::DocumentFragment.parse(result)
+
+      expect(parsed_result.at_css("label").content).to eq "First name"
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,11 @@
 # frozen_string_literal: true
 
+require "action_controller"
+require "action_view"
+require "active_model"
+require "active_support"
+require "nokogiri"
+
 require "citizens_advice_form_builder"
 
 RSpec.configure do |config|


### PR DESCRIPTION
Create basic methods for generating buttons and text input fields.

  - cads_text_field
  - cads_button

For now, these delegate their actual rendering to Rails' built-in form helpers, rather than our design system component library.

Because custom form builders inherit from `ActionView::Helpers::FormBuilder`, all of Rails' standard form tag methods continue to work, which means we can gradually shift over to our new methods without breaking existing behaviour.

NB: I'm using Nokogiri to perform some very simple tests. The plan is to replace these with expectations that check that the design system component methods were called with the correct parameters, which means the tests will continue to work if the underlying HTML the components generate changes in the future.