### PR TITLE
Refactor and move form elements to separate classes

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,6 +14,7 @@ gem "citizens_advice_components",
     tag: "v5.6.0",
     glob: "engine/*.gemspec"
 
+gem "launchy"
 gem "pry"
 gem "rake", "~> 13.0"
 gem "rspec", "~> 3.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -90,6 +90,8 @@ GEM
       reline (>= 0.3.8)
     json (2.6.3)
     language_server-protocol (3.17.0.3)
+    launchy (2.5.2)
+      addressable (~> 2.8)
     loofah (2.22.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.12.0)
@@ -218,6 +220,7 @@ DEPENDENCIES
   citizens-advice-style!
   citizens_advice_components!
   citizens_advice_form_builder!
+  launchy
   pry
   rake (~> 13.0)
   rspec (~> 3.0)

--- a/lib/citizens_advice_form_builder/elements.rb
+++ b/lib/citizens_advice_form_builder/elements.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+require_relative "elements/base"
+require_relative "elements/text_input"

--- a/lib/citizens_advice_form_builder/elements.rb
+++ b/lib/citizens_advice_form_builder/elements.rb
@@ -2,3 +2,4 @@
 
 require_relative "elements/base"
 require_relative "elements/text_input"
+require_relative "elements/button"

--- a/lib/citizens_advice_form_builder/elements/base.rb
+++ b/lib/citizens_advice_form_builder/elements/base.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+module CitizensAdviceFormBuilder
+  module Elements
+    class Base
+      attr_reader :template, :object, :attribute, :options
+
+      def initialize(template, object, attribute, **kwargs)
+        @template = template
+        @object = object
+        @attribute = attribute
+
+        @options = kwargs.with_defaults(default_options)
+      end
+
+      def render
+        # NO OP
+      end
+
+      private
+
+      def current_value
+        object.send(attribute)
+      end
+
+      def default_options
+        {}
+      end
+
+      def error_message
+        object.errors[attribute]&.first
+      end
+
+      def object_name
+        object.to_model.model_name.singular
+      end
+
+      def field_name
+        template.field_name(object_name, attribute)
+      end
+
+      def field_id
+        template.field_id(object_name, attribute)
+      end
+
+      def label
+        options[:label] || object.class.human_attribute_name(attribute)
+      end
+
+      def hint
+        options[:hint]
+      end
+
+      def optional
+        !!!options[:required]
+      end
+    end
+  end
+end

--- a/lib/citizens_advice_form_builder/elements/button.rb
+++ b/lib/citizens_advice_form_builder/elements/button.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+module CitizensAdviceFormBuilder
+  module Elements
+    class Button < Base
+      def initialize(template, object, button_text: nil, **kwargs)
+        super(template, object, nil, **kwargs)
+
+        @button_text = button_text
+      end
+
+      def render
+        component = CitizensAdviceComponents::Button.new(**options)
+        component.with_content(@button_text)
+
+        component.render_in(@template)
+      end
+
+      private
+
+      def default_options
+        { type: :submit, variant: :primary }
+      end
+    end
+  end
+end

--- a/lib/citizens_advice_form_builder/elements/text_input.rb
+++ b/lib/citizens_advice_form_builder/elements/text_input.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+module CitizensAdviceFormBuilder
+  module Elements
+    class TextInput < Base
+      def render
+        component = CitizensAdviceComponents::TextInput.new(
+          name: field_id,
+          label: label,
+          type: :text,
+          options: {
+            hint: hint,
+            optional: optional,
+            value: current_value,
+            error_message: error_message,
+            additional_attributes: { name: field_name }
+          }
+        )
+
+        component.render_in(@template)
+      end
+    end
+  end
+end

--- a/lib/citizens_advice_form_builder/form_builder.rb
+++ b/lib/citizens_advice_form_builder/form_builder.rb
@@ -13,15 +13,12 @@ require CitizensAdviceComponents::Engine.root.join("app", "components", "citizen
 
 module CitizensAdviceFormBuilder
   class FormBuilder < ActionView::Helpers::FormBuilder
-    def cads_text_field(attribute, label: nil, hint: nil, required: false)
-      Elements::TextInput.new(@template, object, attribute, label: label, required: required, hint: hint).render
+    def cads_text_field(attribute, label: nil, hint: nil, required: false, **kwargs)
+      Elements::TextInput.new(@template, object, attribute, label: label, required: required, hint: hint, **kwargs).render
     end
 
-    def cads_button(value = "Save changes")
-      component = CitizensAdviceComponents::Button.new(type: :submit, variant: :primary)
-      component.with_content(value)
-
-      component.render_in(@template)
+    def cads_button(button_text = "Save changes", **kwargs)
+      Elements::Button.new(@template, object, button_text: button_text, **kwargs).render
     end
   end
 end

--- a/lib/citizens_advice_form_builder/form_builder.rb
+++ b/lib/citizens_advice_form_builder/form_builder.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require_relative "elements"
+
 require "action_view"
 require "citizens_advice_components"
 
@@ -12,28 +14,7 @@ require CitizensAdviceComponents::Engine.root.join("app", "components", "citizen
 module CitizensAdviceFormBuilder
   class FormBuilder < ActionView::Helpers::FormBuilder
     def cads_text_field(attribute, label: nil, hint: nil, required: false)
-      label ||= object.class.human_attribute_name(attribute)
-
-      optional = if required
-                   false
-                 else
-                   true
-                 end
-
-      component = CitizensAdviceComponents::TextInput.new(
-        name: id_for(attribute),
-        label: label,
-        type: :text,
-        options: {
-          hint: hint,
-          optional: optional,
-          value: object.send(attribute),
-          error_message: error_message_for(attribute),
-          additional_attributes: { name: name_for(attribute) }
-        }
-      )
-
-      component.render_in(@template)
+      Elements::TextInput.new(@template, object, attribute, label: label, required: required, hint: hint).render
     end
 
     def cads_button(value = "Save changes")
@@ -41,20 +22,6 @@ module CitizensAdviceFormBuilder
       component.with_content(value)
 
       component.render_in(@template)
-    end
-
-    private
-
-    def id_for(attribute)
-      @template.field_id(object_name, attribute)
-    end
-
-    def name_for(attribute)
-      @template.field_name(object_name, attribute)
-    end
-
-    def error_message_for(attribute)
-      object.errors[attribute].first
     end
   end
 end

--- a/spec/citizens_advice_form_builder/elements/button_spec.rb
+++ b/spec/citizens_advice_form_builder/elements/button_spec.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+RSpec.describe CitizensAdviceFormBuilder::Elements::Button do
+  let(:controller) { ActionController::Base.new }
+  let(:lookup_context) { ActionView::LookupContext.new(nil) }
+  let(:template) { ActionView::Base.new(lookup_context, {}, controller) }
+  let(:builder) { CitizensAdviceFormBuilder::FormBuilder.new(:example_form, nil, template, {}) }
+  let(:component_double) { instance_double(component, with_content: nil, render_in: nil) }
+
+  let(:component) { CitizensAdviceComponents::Button }
+
+  before { allow(component).to receive(:new).and_return(component_double) }
+
+  describe "#render" do
+    it "calls the button component with default parameters" do
+      builder.cads_button
+
+      expect(component).to have_received(:new).with(type: :submit, variant: :primary)
+      expect(component_double).to have_received(:with_content).with("Save changes")
+    end
+
+    it "calls the button component with a custom label text" do
+      builder.cads_button "Next"
+
+      expect(component_double).to have_received(:with_content).with("Next")
+    end
+  end
+end

--- a/spec/citizens_advice_form_builder/elements/button_spec.rb
+++ b/spec/citizens_advice_form_builder/elements/button_spec.rb
@@ -4,6 +4,7 @@ RSpec.describe CitizensAdviceFormBuilder::Elements::Button do
   include_context "with view component"
 
   let(:component) { CitizensAdviceComponents::Button }
+  let(:model) { nil } # Buttons don't use model
 
   describe "#render" do
     it "calls the button component with default parameters" do

--- a/spec/citizens_advice_form_builder/elements/button_spec.rb
+++ b/spec/citizens_advice_form_builder/elements/button_spec.rb
@@ -1,15 +1,9 @@
 # frozen_string_literal: true
 
 RSpec.describe CitizensAdviceFormBuilder::Elements::Button do
-  let(:controller) { ActionController::Base.new }
-  let(:lookup_context) { ActionView::LookupContext.new(nil) }
-  let(:template) { ActionView::Base.new(lookup_context, {}, controller) }
-  let(:builder) { CitizensAdviceFormBuilder::FormBuilder.new(:example_form, nil, template, {}) }
-  let(:component_double) { instance_double(component, with_content: nil, render_in: nil) }
+  include_context "with view component"
 
   let(:component) { CitizensAdviceComponents::Button }
-
-  before { allow(component).to receive(:new).and_return(component_double) }
 
   describe "#render" do
     it "calls the button component with default parameters" do

--- a/spec/citizens_advice_form_builder/elements/text_input_spec.rb
+++ b/spec/citizens_advice_form_builder/elements/text_input_spec.rb
@@ -8,21 +8,13 @@ class ExampleForm
   validates :required_field, presence: true
 end
 
-RSpec.describe CitizensAdviceFormBuilder::FormBuilder do
-  let(:controller) { ActionController::Base.new }
-  let(:lookup_context) { ActionView::LookupContext.new(nil) }
-  let(:template) { ActionView::Base.new(lookup_context, {}, controller) }
+RSpec.describe CitizensAdviceFormBuilder::Elements::TextInput do
+  include_context "with view component"
 
+  let(:component) { CitizensAdviceComponents::TextInput }
   let(:model) { ExampleForm.new(name: "Fred Flintstone") }
-  let(:builder) { described_class.new(:example_form, model, template, {}) }
 
-  let(:component_double) { instance_double(component, with_content: nil, render_in: nil) }
-
-  before { allow(component).to receive(:new).and_return(component_double) }
-
-  describe "#cads_text_field" do
-    let(:component) { CitizensAdviceComponents::TextInput }
-
+  describe "#render" do
     it "passes the attribute name to the text input component" do
       builder.cads_text_field(:name)
 

--- a/spec/citizens_advice_form_builder/form_builder_spec.rb
+++ b/spec/citizens_advice_form_builder/form_builder_spec.rb
@@ -20,23 +20,6 @@ RSpec.describe CitizensAdviceFormBuilder::FormBuilder do
 
   before { allow(component).to receive(:new).and_return(component_double) }
 
-  describe "#cads_button" do
-    let(:component) { CitizensAdviceComponents::Button }
-
-    it "calls the button component with default parameters" do
-      builder.cads_button
-
-      expect(component).to have_received(:new).with(type: :submit, variant: :primary)
-      expect(component_double).to have_received(:with_content).with("Save changes")
-    end
-
-    it "calls the button component with a custom label text" do
-      builder.cads_button "Next"
-
-      expect(component_double).to have_received(:with_content).with("Next")
-    end
-  end
-
   describe "#cads_text_field" do
     let(:component) { CitizensAdviceComponents::TextInput }
 

--- a/spec/dummy/app/controllers/elements_controller.rb
+++ b/spec/dummy/app/controllers/elements_controller.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class ElementsController < ApplicationController
+  def index
+    render params[:element]
+  end
+end

--- a/spec/dummy/app/views/elements/buttons.html.erb
+++ b/spec/dummy/app/views/elements/buttons.html.erb
@@ -1,0 +1,13 @@
+<%= form_with do |f| %>
+  <div id="default_button">
+    <%= f.cads_button "Default" %>
+  </div>
+
+  <div id="secondary_button">
+    <%= f.cads_button "Secondary", variant: :secondary %>
+  </div>
+
+  <div id="button_type">
+    <%= f.cads_button "Button", type: :button %>
+  </div>
+<% end %>

--- a/spec/dummy/config/routes.rb
+++ b/spec/dummy/config/routes.rb
@@ -2,4 +2,6 @@
 
 Rails.application.routes.draw do
   resources :example_forms, only: %i[index create]
+
+  get "/elements/:element", to: "elements#index", as: :element
 end

--- a/spec/features/button_spec.rb
+++ b/spec/features/button_spec.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "buttons" do
+  before do
+    visit element_path("buttons")
+  end
+
+  it "renders a default button" do
+    expect(page).to have_css(".cads-button__primary", text: "Default")
+  end
+
+  it "renders a secondary button" do
+    expect(page).to have_css(".cads-button__secondary", text: "Secondary")
+  end
+
+  it "renders a button with type button" do
+    expect(page).to have_css(".cads-button__primary[type=button]", text: "Button")
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -14,6 +14,8 @@ require "citizens_advice_form_builder"
 require_relative "../spec/dummy/config/environment"
 ENV["RAILS_ROOT"] ||= "#{File.dirname(__FILE__)}../../../spec/dummy"
 
+Dir[File.join("./spec", "support", "**", "*.rb")].each { |file| require file }
+
 RSpec.configure do |config|
   # Enable flags like --only-failures and --next-failure
   config.example_status_persistence_file_path = ".rspec_status"

--- a/spec/support/shared/with_view_component.rb
+++ b/spec/support/shared/with_view_component.rb
@@ -4,7 +4,7 @@ RSpec.shared_context "with view component" do
   let(:controller) { ActionController::Base.new }
   let(:lookup_context) { ActionView::LookupContext.new(nil) }
   let(:template) { ActionView::Base.new(lookup_context, {}, controller) }
-  let(:builder) { CitizensAdviceFormBuilder::FormBuilder.new(:example_form, nil, template, {}) }
+  let(:builder) { CitizensAdviceFormBuilder::FormBuilder.new(:form, model, template, {}) }
   let(:component_double) { instance_double(component, with_content: nil, render_in: nil) }
 
   before { allow(component).to receive(:new).and_return(component_double) }

--- a/spec/support/shared/with_view_component.rb
+++ b/spec/support/shared/with_view_component.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+RSpec.shared_context "with view component" do
+  let(:controller) { ActionController::Base.new }
+  let(:lookup_context) { ActionView::LookupContext.new(nil) }
+  let(:template) { ActionView::Base.new(lookup_context, {}, controller) }
+  let(:builder) { CitizensAdviceFormBuilder::FormBuilder.new(:example_form, nil, template, {}) }
+  let(:component_double) { instance_double(component, with_content: nil, render_in: nil) }
+
+  before { allow(component).to receive(:new).and_return(component_double) }
+end


### PR DESCRIPTION
The previous approach was starting to get unwieldy even before all the form elements were added, so this change extracts each form element (text inputs, buttons etc) into their own class.

This keeps everything nicely organised, and feels _far_ easier to read and adapt that the previous solution.