### PR TITLE
Fix `cads_text_area` naming bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## [Unreleased]
 
+## [0.1.1] - 2024-02-22
+
+- Fix `cads_text_area` setting the HTML name attribute incorrectly
+
 ## [0.1.0] - 2023-10-17
 
 - Initial release

--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,7 @@ gem "citizens-advice-style", github: "citizensadvice/citizens-advice-style-ruby"
 
 gem "citizens_advice_components",
     github: "citizensadvice/design-system",
-    tag: "v5.6.0",
+    tag: "v5.7.0",
     glob: "engine/*.gemspec"
 
 gem "launchy"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -10,8 +10,8 @@ GIT
 
 GIT
   remote: https://github.com/citizensadvice/design-system.git
-  revision: 486ba37eec0e0dedd459c9268ff04f7cffd0fb48
-  tag: v5.6.0
+  revision: 3900c39064b82f3e59d0b38c72f707bf1a21e0bf
+  tag: v5.7.0
   glob: engine/*.gemspec
   specs:
     citizens_advice_components (0.1.0)
@@ -22,7 +22,7 @@ GIT
 PATH
   remote: .
   specs:
-    citizens_advice_form_builder (0.1.0)
+    citizens_advice_form_builder (0.1.1)
       actionpack (>= 7.0)
       actionview (>= 7.0)
       activemodel (>= 7.0)

--- a/lib/citizens_advice_form_builder/elements/text_area.rb
+++ b/lib/citizens_advice_form_builder/elements/text_area.rb
@@ -5,7 +5,8 @@ module CitizensAdviceFormBuilder
     class TextArea < Base
       def render
         component = CitizensAdviceComponents::Textarea.new(
-          name: field_id,
+          name: field_name,
+          id: field_id,
           label: label,
           rows: options[:rows],
           options: {

--- a/lib/citizens_advice_form_builder/version.rb
+++ b/lib/citizens_advice_form_builder/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module CitizensAdviceFormBuilder
-  VERSION = "0.1.0"
+  VERSION = "0.1.1"
 end

--- a/spec/citizens_advice_form_builder/elements/text_area_spec.rb
+++ b/spec/citizens_advice_form_builder/elements/text_area_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe CitizensAdviceFormBuilder::Elements::TextArea do
     it "passes the attribute name to the component" do
       builder.cads_text_area(:address)
 
-      expect(component).to have_received(:new).with(hash_including(name: "example_form_address"))
+      expect(component).to have_received(:new).with(hash_including(name: "example_form[address]"))
     end
 
     it "passes the existing value to the component" do

--- a/spec/dummy/app/views/elements/text_inputs.html.erb
+++ b/spec/dummy/app/views/elements/text_inputs.html.erb
@@ -1,0 +1,5 @@
+<%= form_with model: @person, url: request.path do |f| %>
+  <div id="default_text_field">
+    <%= f.cads_text_field :first_name %>
+  </div>
+<% end %>

--- a/spec/features/text_area_spec.rb
+++ b/spec/features/text_area_spec.rb
@@ -7,9 +7,12 @@ RSpec.describe "text areas" do
     visit element_path("text_areas")
   end
 
-  it "renders a default text area" do
+  it "renders a default text area, with 'name' and 'id' set correctly" do
     within "#default_text_area" do
-      expect(page).to have_css("textarea")
+      textarea = page.first("textarea")
+
+      expect(textarea["name"]).to eql "person[address]"
+      expect(textarea["id"]).to eql "person_address-input"
     end
   end
 

--- a/spec/features/text_input_spec.rb
+++ b/spec/features/text_input_spec.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "text inputs" do
+  before do
+    visit element_path("text_inputs")
+  end
+
+  it "renders a default text input, with 'id' and 'name' set correctly" do
+    within "#default_text_field" do
+      input = page.first("input")
+
+      expect(input["name"]).to eql "person[first_name]"
+      expect(input["id"]).to eql "person_first_name-input"
+    end
+  end
+end


### PR DESCRIPTION
The HTML `name` attribute wasn't being set correctly, which was causing form data to not persist as it was being set under the wrong key. 

I've also added missing tests to `cads_text_field` to make sure this bug doesn't crop up there in the future.

Thanks for @marianayovcheva for spotting this bug!