### PR TITLE
Feature/add collection select

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
-## [Unreleased]
+## [0.1.3] - 2024-03-04
+
+- Add `cads_collection_select` method
 
 ## [0.1.2] - 2024-02-23
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -107,6 +107,8 @@ GEM
     mutex_m (0.2.0)
     nokogiri (1.16.2-arm64-darwin)
       racc (~> 1.4)
+    nokogiri (1.16.2-x86_64-darwin)
+      racc (~> 1.4)
     nokogiri (1.16.2-x86_64-linux)
       racc (~> 1.4)
     parallel (1.23.0)
@@ -218,6 +220,7 @@ GEM
 
 PLATFORMS
   arm64-darwin-23
+  x86_64-darwin-22
   x86_64-linux
 
 DEPENDENCIES

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -22,7 +22,7 @@ GIT
 PATH
   remote: .
   specs:
-    citizens_advice_form_builder (0.1.2)
+    citizens_advice_form_builder (0.1.3)
       actionpack (>= 7.0)
       actionview (>= 7.0)
       activemodel (>= 7.0)

--- a/lib/citizens_advice_form_builder/elements.rb
+++ b/lib/citizens_advice_form_builder/elements.rb
@@ -8,3 +8,4 @@ require_relative "elements/date_input"
 
 require_relative "elements/collections/radio_buttons"
 require_relative "elements/collections/check_boxes"
+require_relative "elements/collections/select"

--- a/lib/citizens_advice_form_builder/elements/collections/select.rb
+++ b/lib/citizens_advice_form_builder/elements/collections/select.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+module CitizensAdviceFormBuilder
+  module Elements
+    module Collections
+      class Select < Base
+        include ActionView::Helpers::FormOptionsHelper
+
+        def render
+          component = CitizensAdviceComponents::Select.new(
+            select_options: items,
+            name: field_id,
+            label: label,
+            options: {
+              hint: hint,
+              optional: optional,
+              error_message: error_message,
+              value: current_value,
+              additional_attributes: { name: field_name }
+            }
+          )
+
+          component.render_in(@template)
+        end
+
+        private
+
+        def items
+          @options[:collection].map do |item|
+            label = value_for_collection(item, text_method)
+            value = value_for_collection(item, value_method)
+
+            [label, value]
+          end
+        end
+
+        def text_method
+          @options[:text_method]
+        end
+
+        def value_method
+          @options[:value_method] || text_method
+        end
+      end
+    end
+  end
+end

--- a/lib/citizens_advice_form_builder/form_builder.rb
+++ b/lib/citizens_advice_form_builder/form_builder.rb
@@ -38,6 +38,10 @@ module CitizensAdviceFormBuilder
       Elements::Collections::CheckBoxes.new(@template, object, attribute, label: label, hint: hint, required: required, **kwargs).render
     end
 
+    def cads_collection_select(attribute, label: nil, hint: nil, required: false, **kwargs)
+      Elements::Collections::Select.new(@template, object, attribute, label: label, hint: hint, required: required, **kwargs).render
+    end
+
     def cads_button(button_text = "Save changes", **kwargs)
       Elements::Button.new(@template, object, button_text: button_text, **kwargs).render
     end

--- a/lib/citizens_advice_form_builder/version.rb
+++ b/lib/citizens_advice_form_builder/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module CitizensAdviceFormBuilder
-  VERSION = "0.1.2"
+  VERSION = "0.1.3"
 end

--- a/spec/citizens_advice_form_builder/elements/collections/select_spec.rb
+++ b/spec/citizens_advice_form_builder/elements/collections/select_spec.rb
@@ -1,0 +1,100 @@
+# frozen_string_literal: true
+
+class ExampleForm
+  include ActiveModel::Model
+
+  attr_accessor :ice_cream
+end
+
+RSpec.describe CitizensAdviceFormBuilder::Elements::Collections::Select do
+  include_context "with view component"
+
+  let(:component) { CitizensAdviceComponents::Select }
+  let(:component_double) { instance_double(component, render_in: nil) }
+  let(:model) { ExampleForm.new(ice_cream: "0002") }
+
+  describe "#render" do
+    let(:ice_cream) { Struct.new(:reference, :colour, :name) }
+
+    let(:collection) do
+      [
+        ice_cream.new("0001", "Blue", "Bubble gum"),
+        ice_cream.new("0002", "Green", "Pistachio"),
+        ice_cream.new("0003", "Pink", "Strawberry")
+      ]
+    end
+
+    it "passes the attribute name to the radio group component" do
+      builder.cads_collection_select(:ice_cream, collection: collection, text_method: :name, value_method: :reference)
+
+      expect(component).to have_received(:new).with(hash_including(name: "example_form_ice_cream"))
+    end
+
+    it "passes the collection, reformatted with 'label', 'value' and 'checked' keys to the radio group component" do
+      builder.cads_collection_select(:ice_cream, collection: collection, text_method: :name, value_method: :reference)
+
+      expect(component).to have_received(:new).with(hash_including(select_options: [["Bubble gum", "0001"], ["Pistachio", "0002"],
+                                                                                    ["Strawberry", "0003"]]))
+    end
+
+    it "sets 'optional' to 'true' by default" do
+      builder.cads_collection_select(:ice_cream, collection: collection, text_method: :name, value_method: :reference)
+
+      expect(component).to have_received(:new).with(hash_including(options: hash_including(optional: true)))
+    end
+
+    context "with 'required' parameter" do
+      # rubocop:disable RSpec/ExampleLength
+      it "sets 'optional' to 'false' when true" do
+        builder.cads_collection_select(
+          :ice_cream,
+          collection: collection,
+          text_method: :name,
+          value_method: :reference,
+          required: true
+        )
+
+        expect(component).to have_received(:new).with(hash_including(options: hash_including(optional: false)))
+      end
+
+      it "sets 'optional' to 'true' when false" do
+        builder.cads_collection_select(
+          :ice_cream,
+          collection: collection,
+          text_method: :name,
+          value_method: :reference,
+          required: false
+        )
+
+        expect(component).to have_received(:new).with(hash_including(options: hash_including(optional: true)))
+      end
+      # rubocop:enable RSpec/ExampleLength
+    end
+
+    context "with 'hint' parameter" do
+      # rubocop:disable RSpec/ExampleLength
+      it "passes hint to the text input component" do
+        builder.cads_collection_select(
+          :ice_cream,
+          collection: collection,
+          text_method: :name,
+          value_method: :reference,
+          hint: "Example hint"
+        )
+
+        expect(component).to have_received(:new).with(hash_including(options: hash_including(hint: "Example hint")))
+      end
+      # rubocop:enable RSpec/ExampleLength
+    end
+
+    context "when there is a validation error" do
+      it "sets 'error_message'" do
+        model.errors.add(:ice_cream, :example, message: "example error")
+
+        builder.cads_collection_select(:ice_cream, collection: collection, text_method: :name, value_method: :reference)
+
+        expect(component).to have_received(:new).with(hash_including(options: hash_including(error_message: "example error")))
+      end
+    end
+  end
+end

--- a/spec/dummy/app/models/person.rb
+++ b/spec/dummy/app/models/person.rb
@@ -7,7 +7,7 @@ class Person
   include ActiveModel::Attributes
   include ActiveRecord::AttributeAssignment
 
-  attr_accessor :first_name, :last_name, :address, :date_with_hint, :required_date, :favourite_drink, :pizza_toppings
+  attr_accessor :first_name, :last_name, :address, :date_with_hint, :required_date, :favourite_drink, :pizza_toppings, :ice_cream
 
   attribute :date_of_birth, :date
   attribute :pizza_toppings, array: true

--- a/spec/dummy/app/views/elements/collection_select.erb
+++ b/spec/dummy/app/views/elements/collection_select.erb
@@ -1,0 +1,5 @@
+<%= form_with model: @person, url: request.path do |f| %>
+  <div id="default_collection_select">
+    <%= f.cads_collection_select :ice_cream, label: "Favourite ice cream", collection: [["Vanilla", "0000"], ["Chocolate", "0001"], ["Strawberry", "0002"], ["Pistachio", "0003"], ["Cookie dough", "0004"], ["Salted caramel", "0005"]], text_method: :first, value_method: :last %>
+  </div>
+<% end %>

--- a/spec/features/collection_select_spec.rb
+++ b/spec/features/collection_select_spec.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "collection radio buttons" do
+  before do
+    visit element_path("collection_select")
+  end
+
+  it "renders a number of radio buttons" do
+    within "#default_collection_select" do
+      expect(page).to have_select("Favourite ice cream",
+                                  options: ["Vanilla", "Chocolate", "Strawberry", "Pistachio", "Cookie dough", "Salted caramel"])
+    end
+  end
+end


### PR DESCRIPTION
Adding the design system select component.
This PR is heavily influenced by how we add the radio buttons. The main difference is passing the `select_options`.
I'm planning to run the release process and update the changelog and gem version as part of this PR but after it gets approved.