### PR TITLE
Bump citizens_advice_form_builder to 0.1.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [0.1.4] - 2024-04-26
+
+- Add error handling to `cads_date_field`
+
 ## [0.1.3] - 2024-03-04
 
 - Add `cads_collection_select` method

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -22,7 +22,7 @@ GIT
 PATH
   remote: .
   specs:
-    citizens_advice_form_builder (0.1.3)
+    citizens_advice_form_builder (0.1.4)
       actionpack (>= 7.0)
       actionview (>= 7.0)
       activemodel (>= 7.0)

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -10,8 +10,8 @@ Enter `gem install gem-release` to install on your local machine.
 
 ## Release Process
 
+- Use `gem bump -v patch` to bump the patch release number of the gem
 - Update `CHANGELOG.md` with any changes going into this release
-- Use `gem bump -v minor` to bump the minor release number of the gem
 - Use `gem tag` to create a git tag for the new version
 - Push the tag up to the git remote with `git push origin --tags`
 - Open a PR and get it merged into main

--- a/lib/citizens_advice_form_builder/version.rb
+++ b/lib/citizens_advice_form_builder/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module CitizensAdviceFormBuilder
-  VERSION = "0.1.3"
+  VERSION = "0.1.4"
 end


### PR DESCRIPTION
Changelog:

- Add error handling to `cads_date_field`
- Fix release instructions