### PR TITLE
Add `cads_error_summary`

### DIFF
--- a/lib/citizens_advice_form_builder/elements.rb
+++ b/lib/citizens_advice_form_builder/elements.rb
@@ -5,6 +5,7 @@ require_relative "elements/text_input"
 require_relative "elements/button"
 require_relative "elements/text_area"
 require_relative "elements/date_input"
+require_relative "elements/error_summary"
 
 require_relative "elements/collections/radio_buttons"
 require_relative "elements/collections/check_boxes"

--- a/lib/citizens_advice_form_builder/elements/error_summary.rb
+++ b/lib/citizens_advice_form_builder/elements/error_summary.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+module CitizensAdviceFormBuilder
+  module Elements
+    class ErrorSummary < Base
+      def render
+        component = CitizensAdviceComponents::ErrorSummary.new
+        component.with_errors(error_messages)
+
+        component.render_in(@template)
+      end
+
+      private
+
+      def error_messages
+        object.errors.group_by_attribute.map do |attr, errors|
+          {
+            href: "##{field_id_for(attr)}-error",
+            message: errors.first.full_message
+          }
+        end
+      end
+
+      def field_id_for(attribute)
+        @template.field_id(object_name, attribute)
+      end
+    end
+  end
+end

--- a/lib/citizens_advice_form_builder/form_builder.rb
+++ b/lib/citizens_advice_form_builder/form_builder.rb
@@ -15,6 +15,7 @@ require CitizensAdviceComponents::Engine.root.join("app", "components", "citizen
 require CitizensAdviceComponents::Engine.root.join("app", "components", "citizens_advice_components", "checkable", "base")
 require CitizensAdviceComponents::Engine.root.join("app", "components", "citizens_advice_components", "checkable", "radio")
 require CitizensAdviceComponents::Engine.root.join("app", "components", "citizens_advice_components", "radio_group")
+require CitizensAdviceComponents::Engine.root.join("app", "components", "citizens_advice_components", "error_summary")
 
 module CitizensAdviceFormBuilder
   class FormBuilder < ActionView::Helpers::FormBuilder
@@ -44,6 +45,10 @@ module CitizensAdviceFormBuilder
 
     def cads_button(button_text = "Save changes", **kwargs)
       Elements::Button.new(@template, object, button_text: button_text, **kwargs).render
+    end
+
+    def cads_error_summary
+      Elements::ErrorSummary.new(@template, object, :unused).render
     end
   end
 end

--- a/spec/dummy/app/views/elements/error_summary.html.erb
+++ b/spec/dummy/app/views/elements/error_summary.html.erb
@@ -1,0 +1,8 @@
+<%= form_with model: @person, url: request.path do |f| %>
+  <%= f.cads_error_summary %>
+
+  <%= f.cads_text_field :first_name, required: true %>
+  <%= f.cads_date_field :date_of_birth, required: true %>
+
+  <%= f.submit %>
+<% end %>

--- a/spec/dummy/app/views/example_forms/index.html.erb
+++ b/spec/dummy/app/views/example_forms/index.html.erb
@@ -1,6 +1,8 @@
 <h1>Example form</h1>
 
 <%= form_with model: @person, url: example_forms_path, method: :post do |f| %>
+  <%= f.cads_error_summary %>
+
   <%= f.cads_text_field :first_name %>
   <%= f.cads_text_field :last_name %>
   <%= f.cads_button "Save" %>

--- a/spec/features/error_summary_spec.rb
+++ b/spec/features/error_summary_spec.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "error summary" do
+  before do
+    visit element_path("error_summary")
+  end
+
+  it "doesn't show the error summary if there are no errors" do
+    expect(page).not_to have_css("div.cads-error-summary")
+  end
+
+  context "with validation errors" do
+    before { click_button }
+
+    it "shows errors within an error summary component" do
+      error_summaries = page.find_all(".cads-error-summary__list a")
+      error_hrefs = error_summaries.map { |a| a["href"] }
+      error_messages = error_summaries.map(&:text)
+
+      expect(error_hrefs).to contain_exactly("#person_first_name-error", "#person_date_of_birth-error")
+      expect(error_messages).to contain_exactly("First name can't be blank", "Date of birth can't be blank")
+    end
+  end
+end


### PR DESCRIPTION
This method formats a model's `errors` object and passes that to the [CitizensAdviceComponents::ErrorSummary](https://citizens-advice-design-system.netlify.app/components/error-summary/#using-with-rails) component in the design system for rendering.

## Example output

![Screenshot 2024-04-29 at 10 12 25](https://github.com/citizensadvice/rails-form-builder/assets/3166/a6efad85-56bb-4489-907b-3335ef6d2f3e)