### PR TITLE
Allow icons to be added to the left or right of `cads_button` elements

### DIFF
--- a/lib/citizens_advice_form_builder/elements/base.rb
+++ b/lib/citizens_advice_form_builder/elements/base.rb
@@ -9,7 +9,8 @@ module CitizensAdviceFormBuilder
 
       delegate :content_tag, :tag, :safe_join, :link_to, :capture, to: :@template
 
-      attr_reader :template, :object, :attribute, :options
+      attr_reader :template, :object, :attribute
+      attr_accessor :options
 
       def initialize(template, object, attribute, **kwargs)
         @template = template

--- a/lib/citizens_advice_form_builder/elements/button.rb
+++ b/lib/citizens_advice_form_builder/elements/button.rb
@@ -3,29 +3,22 @@
 module CitizensAdviceFormBuilder
   module Elements
     class Button < Base
-      def initialize(template, object, button_text: nil, icon_left: nil, icon_right: nil, **kwargs)
+      def initialize(template, object, button_text: nil, **kwargs)
         super(template, object, nil, **kwargs)
 
         @button_text = button_text
-        @icon_left = icon_left
-        @icon_right = icon_right
+        @icon_left = options[:icon_left]
+        @icon_right = options[:icon_right]
+
+        @options.except!(:icon_left, :icon_right)
       end
 
       def render
         component = CitizensAdviceComponents::Button.new(**options)
         component.with_content(@button_text)
 
-        if @icon_left
-          component.with_icon_left do
-            icon_left_class.new.render_in(@template)
-          end
-        end
-
-        if @icon_right
-          component.with_icon_right do
-            icon_right_class.new.render_in(@template)
-          end
-        end
+        add_icon_left(component) if @icon_left
+        add_icon_right(component) if @icon_right
 
         component.render_in(@template)
       end
@@ -34,6 +27,18 @@ module CitizensAdviceFormBuilder
 
       def default_options
         { type: :submit, variant: :primary }
+      end
+
+      def add_icon_left(component)
+        component.with_icon_left do
+          icon_left_class.new.render_in(@template)
+        end
+      end
+
+      def add_icon_right(component)
+        component.with_icon_right do
+          icon_right_class.new.render_in(@template)
+        end
       end
 
       def icon_left_class

--- a/lib/citizens_advice_form_builder/elements/button.rb
+++ b/lib/citizens_advice_form_builder/elements/button.rb
@@ -3,15 +3,29 @@
 module CitizensAdviceFormBuilder
   module Elements
     class Button < Base
-      def initialize(template, object, button_text: nil, **kwargs)
+      def initialize(template, object, button_text: nil, icon_left: nil, icon_right: nil, **kwargs)
         super(template, object, nil, **kwargs)
 
         @button_text = button_text
+        @icon_left = icon_left
+        @icon_right = icon_right
       end
 
       def render
         component = CitizensAdviceComponents::Button.new(**options)
         component.with_content(@button_text)
+
+        if @icon_left
+          component.with_icon_left do
+            icon_left_class.new.render_in(@template)
+          end
+        end
+
+        if @icon_right
+          component.with_icon_right do
+            icon_right_class.new.render_in(@template)
+          end
+        end
 
         component.render_in(@template)
       end
@@ -20,6 +34,14 @@ module CitizensAdviceFormBuilder
 
       def default_options
         { type: :submit, variant: :primary }
+      end
+
+      def icon_left_class
+        "CitizensAdviceComponents::Icons::#{@icon_left.to_s.camelize}".constantize
+      end
+
+      def icon_right_class
+        "CitizensAdviceComponents::Icons::#{@icon_right.to_s.camelize}".constantize
       end
     end
   end

--- a/spec/dummy/app/views/elements/buttons.html.erb
+++ b/spec/dummy/app/views/elements/buttons.html.erb
@@ -10,4 +10,12 @@
   <div id="button_type">
     <%= f.cads_button "Button", type: :button %>
   </div>
+
+  <div id="icon_left">
+    <%= f.cads_button "Button", icon_left: :arrow_left %>
+  </div>
+
+  <div id="icon_right">
+    <%= f.cads_button "Icon Right", icon_right: :arrow_right %>
+  </div>
 <% end %>

--- a/spec/features/button_spec.rb
+++ b/spec/features/button_spec.rb
@@ -18,4 +18,20 @@ RSpec.describe "buttons" do
   it "renders a button with type button" do
     expect(page).to have_css(".cads-button__primary[type=button]", text: "Button")
   end
+
+  context "with icons" do
+    it "renders icon on the left side of button" do
+      within "#icon_left" do
+        expect(page).to have_css("span.cads-button__icon-left")
+        expect(page).to have_css("svg.cads-icon--arrow-left")
+      end
+    end
+
+    it "renders icon on the right side of button" do
+      within "#icon_right" do
+        expect(page).to have_css("span.cads-button__icon-right")
+        expect(page).to have_css("svg.cads-icon--arrow-right")
+      end
+    end
+  end
 end


### PR DESCRIPTION
Allow any [icon from the design system](https://citizens-advice-design-system.netlify.app/foundations/icons/) to be added to the left or right of a `cads_button`.

These are passed as snake-cased symbols, e.g:

```ruby
# Uses icon from CitizensAdviceComponents::Icons::ArrowRight
form.cads.button "Next", icon_right: :arrow_right

# Uses icon from CitizensAdviceComponents::Icons::ArrowLeft
form.cads.button "Previous", icon_left: :arrow_left
```

This produces:

![Screenshot 2024-05-16 at 10 24 22](https://github.com/citizensadvice/rails-form-builder/assets/3166/9a99762e-412e-47af-8eb7-fa1e662e5e91)

