### PR TITLE
Add support for width attribute to text inputs

### DIFF
--- a/lib/citizens_advice_form_builder/elements/text_input.rb
+++ b/lib/citizens_advice_form_builder/elements/text_input.rb
@@ -8,6 +8,7 @@ module CitizensAdviceFormBuilder
           name: field_id,
           label: label,
           type: :text,
+          width: options[:width],
           options: {
             hint: hint,
             optional: optional,

--- a/spec/dummy/app/views/elements/text_inputs.html.erb
+++ b/spec/dummy/app/views/elements/text_inputs.html.erb
@@ -2,4 +2,8 @@
   <div id="default_text_field">
     <%= f.cads_text_field :first_name %>
   </div>
+
+  <div id="text_field_with_width">
+    <%= f.cads_text_field :first_name, width: :four_chars %>
+  </div>
 <% end %>

--- a/spec/features/text_input_spec.rb
+++ b/spec/features/text_input_spec.rb
@@ -15,4 +15,12 @@ RSpec.describe "text inputs" do
       expect(input["id"]).to eql "person_first_name-input"
     end
   end
+
+  describe "width attributes" do
+    it "renders the associated width input" do
+      within "#text_field_with_width" do
+        expect(page).to have_css ".cads-input--four-chars"
+      end
+    end
+  end
 end


### PR DESCRIPTION
👋 Consider this a bit of a test PR based on our discussion earlier @leeky and @marianayovcheva. Wanted to have a go contributing a new option to one of the inputs and thought adding the `width` to text inputs would be a good candidate.