### PR TITLE
Test against all active Ruby versions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,7 +18,7 @@ jobs:
         ruby: ["3.1", "3.2", "3.3"]
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,10 +14,8 @@ jobs:
     name: Ruby ${{ matrix.ruby }}
     strategy:
       matrix:
-        ruby:
-          - '3.0.6'
-          - '3.1.4'
-          - '3.2.1'
+        # Active Ruby versions (https://endoflife.date/ruby)
+        ruby: ["3.1", "3.2", "3.3"]
 
     steps:
       - uses: actions/checkout@v3

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -6,8 +6,14 @@ inherit_gem:
 require: rubocop-rake
 
 AllCops:
-  TargetRubyVersion: 3.0
   SuggestExtensions: false
+  # Match minimum target version to gemspec
+  TargetRubyVersion: 3.1
+
+Style/HashSyntax:
+  # We do not necessarily find that Ruby 3.1’s hash value shorthand syntax
+  # encourages greater readability so support either style
+  EnforcedShorthandSyntax: "either"
 
 RSpec/MultipleExpectations:
   Enabled: false

--- a/citizens_advice_form_builder.gemspec
+++ b/citizens_advice_form_builder.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |spec|
 
   spec.summary = "Citizens Advice custom Rails form builder"
   spec.homepage = "https://github.com/citizensadvice/rails-form-builder"
-  spec.required_ruby_version = ">= 3.0.0"
+  spec.required_ruby_version = Gem::Requirement.new(">= 3.1")
 
   spec.metadata["homepage_uri"] = spec.homepage
   spec.metadata["source_code_uri"] = spec.homepage


### PR DESCRIPTION
Proposes an adjustment to the CI pipeline to mirror the design-system and test against the three active Ruby version (Removing Ruby 3.0.x as it is EOL).