### PR TITLE
Bump citizens_advice_form_builder to 0.1.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [0.1.5] - 2024-06-21
+
+- Add `cads_error_summary`
+- Allow icons to be added to buttons
+- Add support for width attribute to text inputs (thanks @davidrapson)
+- Fix submission of empty checkbox groups by including hidden field
+
 ## [0.1.4] - 2024-04-26
 
 - Add error handling to `cads_date_field`

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -22,7 +22,7 @@ GIT
 PATH
   remote: .
   specs:
-    citizens_advice_form_builder (0.1.4)
+    citizens_advice_form_builder (0.1.5)
       actionpack (>= 7.0)
       actionview (>= 7.0)
       activemodel (>= 7.0)

--- a/lib/citizens_advice_form_builder/version.rb
+++ b/lib/citizens_advice_form_builder/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module CitizensAdviceFormBuilder
-  VERSION = "0.1.4"
+  VERSION = "0.1.5"
 end


### PR DESCRIPTION
- Add `cads_error_summary`
- Allow [icons](https://citizens-advice-design-system.netlify.app/foundations/icons/) to be added to buttons
- Add support for width attribute to text inputs (thanks @davidrapson 🎉 )
- Fix submission of empty checkbox groups by including hidden field