### PR TITLE
Include attribute name in error messages

### DIFF
--- a/lib/citizens_advice_form_builder/elements/base.rb
+++ b/lib/citizens_advice_form_builder/elements/base.rb
@@ -35,7 +35,7 @@ module CitizensAdviceFormBuilder
       end
 
       def error_message
-        object.errors[attribute]&.first
+        object.errors.full_messages_for(attribute)&.first
       end
 
       def object_name

--- a/spec/citizens_advice_form_builder/elements/collections/select_spec.rb
+++ b/spec/citizens_advice_form_builder/elements/collections/select_spec.rb
@@ -89,11 +89,13 @@ RSpec.describe CitizensAdviceFormBuilder::Elements::Collections::Select do
 
     context "when there is a validation error" do
       it "sets 'error_message'" do
-        model.errors.add(:ice_cream, :example, message: "example error")
+        model.errors.add(:ice_cream, :example, message: "has an example error")
 
         builder.cads_collection_select(:ice_cream, collection: collection, text_method: :name, value_method: :reference)
 
-        expect(component).to have_received(:new).with(hash_including(options: hash_including(error_message: "example error")))
+        expect(component).to have_received(:new).with(
+          hash_including(options: hash_including(error_message: "Ice cream has an example error"))
+        )
       end
     end
   end

--- a/spec/citizens_advice_form_builder/elements/text_area_spec.rb
+++ b/spec/citizens_advice_form_builder/elements/text_area_spec.rb
@@ -63,7 +63,7 @@ RSpec.describe CitizensAdviceFormBuilder::Elements::TextArea do
 
     context "when there is a validation error" do
       it "sets 'error_message'" do
-        model.errors.add(:address, :presence, message: "Address is required")
+        model.errors.add(:address, :presence, message: "is required")
 
         builder.cads_text_area(:address)
 

--- a/spec/citizens_advice_form_builder/elements/text_input_spec.rb
+++ b/spec/citizens_advice_form_builder/elements/text_input_spec.rb
@@ -63,11 +63,11 @@ RSpec.describe CitizensAdviceFormBuilder::Elements::TextInput do
 
     context "when there is a validation error" do
       it "sets 'error_message'" do
-        model.errors.add(:name, :example, message: "example error")
+        model.errors.add(:name, :example, message: "has an example error")
 
         builder.cads_text_field(:name)
 
-        expect(component).to have_received(:new).with(hash_including(options: hash_including(error_message: "example error")))
+        expect(component).to have_received(:new).with(hash_including(options: hash_including(error_message: "Name has an example error")))
       end
     end
   end


### PR DESCRIPTION
I was incorrectly using the `object.errors` array when returning validation error messages, which didn't include the attribute, this led to confusing errors "cannot be blank" rather than the more useful "Name cannot be blank".