### PR TITLE
Amend text input interface

### DIFF
--- a/lib/citizens_advice_form_builder/elements/text_input.rb
+++ b/lib/citizens_advice_form_builder/elements/text_input.rb
@@ -5,7 +5,8 @@ module CitizensAdviceFormBuilder
     class TextInput < Base
       def render
         component = CitizensAdviceComponents::TextInput.new(
-          name: field_id,
+          name: field_name,
+          id: field_id,
           label: label,
           type: :text,
           width: options[:width],
@@ -14,7 +15,7 @@ module CitizensAdviceFormBuilder
             optional: optional,
             value: current_value,
             error_message: error_message,
-            additional_attributes: { name: field_name }
+            additional_attributes: options[:additional_attributes]
           }
         )
 

--- a/spec/citizens_advice_form_builder/elements/text_input_spec.rb
+++ b/spec/citizens_advice_form_builder/elements/text_input_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe CitizensAdviceFormBuilder::Elements::TextInput do
     it "passes the attribute name to the text input component" do
       builder.cads_text_field(:name)
 
-      expect(component).to have_received(:new).with(hash_including(name: "example_form_name"))
+      expect(component).to have_received(:new).with(hash_including(name: "example_form[name]"))
     end
 
     it "passes the attribute's existing value to the text input component" do
@@ -31,6 +31,14 @@ RSpec.describe CitizensAdviceFormBuilder::Elements::TextInput do
       builder.cads_text_field(:name, label: "First name")
 
       expect(component).to have_received(:new).with(hash_including(label: "First name"))
+    end
+
+    it "passes additional attributes to the text input component" do
+      builder.cads_text_field(:name, additional_attributes: { "data-example": "custom-attribute" })
+
+      expect(component).to have_received(:new).with(
+        hash_including(options: hash_including(additional_attributes: { "data-example": "custom-attribute" }))
+      )
     end
 
     it "sets 'optional' to 'true' by default" do

--- a/spec/dummy/app/views/elements/text_inputs.html.erb
+++ b/spec/dummy/app/views/elements/text_inputs.html.erb
@@ -6,4 +6,8 @@
   <div id="text_field_with_width">
     <%= f.cads_text_field :first_name, width: :four_chars %>
   </div>
+
+  <div id="text_field_with_additional_attributes">
+    <%= f.cads_text_field :first_name, additional_attributes: { "data-example": "custom-attribute" } %>
+  </div>
 <% end %>

--- a/spec/features/text_input_spec.rb
+++ b/spec/features/text_input_spec.rb
@@ -23,4 +23,12 @@ RSpec.describe "text inputs" do
       end
     end
   end
+
+  describe "additional attributes" do
+    it "renders additional attributes passed to the field" do
+      within "#text_field_with_additional_attributes" do
+        expect(page).to have_css "input[data-example='custom-attribute']"
+      end
+    end
+  end
 end


### PR DESCRIPTION
The text input was setting the name using the top-level `name` property but with the ID value and then again in additional attributes to the correct value. Avoid the double setting and fix the element spec.

Also passes all additional attributes through to the component in keeping with the other field types.