### PR TITLE
Support multiple Rails versions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,18 +11,23 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    name: Ruby ${{ matrix.ruby }}
+    name: Ruby ${{ matrix.ruby_version }}, Rails ${{ matrix.rails_version }}
     strategy:
       matrix:
         # Active Ruby versions (https://endoflife.date/ruby)
-        ruby: ["3.1", "3.2", "3.3"]
-
+        ruby_version: ['3.1', '3.2', '3.3']
+        # Last 3 major Rails releases
+        rails_version: ['~> 6.1', '~> 7.0.0', '~> 7.1.0']
+    env:
+      RAILS_VERSION: ${{ matrix.rails_version }}
     steps:
       - uses: actions/checkout@v4
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: ${{ matrix.ruby }}
-          bundler-cache: true
-      - name: Run the default task
+          ruby-version: ${{ matrix.ruby_version }}
+      - run: |
+          bundle config path vendor/bundle
+          bundle install --jobs 4 --retry 3
+      - name: Run tests
         run: bundle exec rake

--- a/Gemfile
+++ b/Gemfile
@@ -5,18 +5,28 @@ source "https://rubygems.org"
 # Specify your gem's dependencies in citizens_advice_form_builder.gemspec
 gemspec
 
-gem "capybara"
-
-gem "citizens-advice-style", github: "citizensadvice/citizens-advice-style-ruby", tag: "v10.0.1"
-
 gem "citizens_advice_components",
     github: "citizensadvice/design-system",
     tag: "v5.7.0",
     glob: "engine/*.gemspec"
 
-gem "launchy"
-gem "pry"
-gem "rake", "~> 13.0"
-gem "rspec", "~> 3.0"
-gem "rspec-rails"
-gem "rubocop-rake"
+rails_version = ENV.fetch("RAILS_VERSION", "~> 7.1.0").to_s
+
+gem "actionpack", rails_version
+gem "actionview", rails_version
+gem "activerecord", rails_version
+gem "activesupport", rails_version
+
+group :development, :test do
+  gem "citizens-advice-style",
+      github: "citizensadvice/citizens-advice-style-ruby",
+      tag: "v10.0.1"
+
+  gem "capybara"
+  gem "launchy"
+  gem "pry"
+  gem "rake", "~> 13.0"
+  gem "rspec", "~> 3.0"
+  gem "rspec-rails"
+  gem "rubocop-rake"
+end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -23,11 +23,11 @@ PATH
   remote: .
   specs:
     citizens_advice_form_builder (0.1.5)
-      actionpack (>= 7.0)
-      actionview (>= 7.0)
-      activemodel (>= 7.0)
-      activerecord (>= 7.0)
-      activesupport (>= 7.0)
+      actionpack (>= 6.0.0, < 8.0)
+      actionview (>= 6.0.0, < 8.0)
+      activemodel (>= 6.0.0, < 8.0)
+      activerecord (>= 6.0.0, < 8.0)
+      activesupport (>= 6.0.0, < 8.0)
       citizens_advice_components
 
 GEM
@@ -70,7 +70,7 @@ GEM
     ast (2.4.2)
     base64 (0.1.1)
     bigdecimal (3.1.8)
-    builder (3.2.4)
+    builder (3.3.0)
     capybara (3.39.2)
       addressable
       matrix
@@ -86,13 +86,13 @@ GEM
     crass (1.0.6)
     diff-lcs (1.5.0)
     drb (2.2.1)
-    erubi (1.12.0)
+    erubi (1.13.0)
     i18n (1.14.5)
       concurrent-ruby (~> 1.0)
-    io-console (0.6.0)
-    irb (1.9.1)
-      rdoc
-      reline (>= 0.3.8)
+    io-console (0.7.2)
+    irb (1.13.2)
+      rdoc (>= 4.0.0)
+      reline (>= 0.4.2)
     json (2.6.3)
     language_server-protocol (3.17.0.3)
     launchy (2.5.2)
@@ -103,7 +103,7 @@ GEM
     matrix (0.4.2)
     method_source (1.0.0)
     mini_mime (1.1.5)
-    minitest (5.23.1)
+    minitest (5.24.0)
     mutex_m (0.2.0)
     nokogiri (1.16.5-arm64-darwin)
       racc (~> 1.4)
@@ -122,14 +122,14 @@ GEM
       stringio
     public_suffix (5.0.4)
     racc (1.8.0)
-    rack (3.0.11)
-    rack-session (2.0.0)
-      rack (>= 3.0.0)
+    rack (2.2.9)
+    rack-session (1.0.2)
+      rack (< 3)
     rack-test (2.1.0)
       rack (>= 1.3)
-    rackup (2.1.0)
-      rack (>= 3)
-      webrick (~> 1.8)
+    rackup (1.0.0)
+      rack (< 3)
+      webrick
     rails-dom-testing (2.2.0)
       activesupport (>= 5.0.0)
       minitest
@@ -147,10 +147,10 @@ GEM
       zeitwerk (~> 2.6)
     rainbow (3.1.1)
     rake (13.0.6)
-    rdoc (6.6.3.1)
+    rdoc (6.7.0)
       psych (>= 4.0.0)
     regexp_parser (2.8.2)
-    reline (0.4.1)
+    reline (0.5.9)
       io-console (~> 0.5)
     rexml (3.2.8)
       strscan (>= 3.0.9)
@@ -204,9 +204,9 @@ GEM
       rubocop-capybara (~> 2.17)
       rubocop-factory_bot (~> 2.22)
     ruby-progressbar (1.13.0)
-    stringio (3.1.0)
+    stringio (3.1.1)
     strscan (3.1.0)
-    thor (1.3.0)
+    thor (1.3.1)
     timeout (0.4.1)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
@@ -218,14 +218,19 @@ GEM
     webrick (1.8.1)
     xpath (3.2.0)
       nokogiri (~> 1.8)
-    zeitwerk (2.6.12)
+    zeitwerk (2.6.16)
 
 PLATFORMS
   arm64-darwin-23
   x86_64-darwin-22
+  x86_64-darwin-23
   x86_64-linux
 
 DEPENDENCIES
+  actionpack (~> 7.1.0)
+  actionview (~> 7.1.0)
+  activerecord (~> 7.1.0)
+  activesupport (~> 7.1.0)
   capybara
   citizens-advice-style!
   citizens_advice_components!

--- a/citizens_advice_form_builder.gemspec
+++ b/citizens_advice_form_builder.gemspec
@@ -29,11 +29,9 @@ Gem::Specification.new do |spec|
   spec.executables = spec.files.grep(%r{\Aexe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "actionpack", ">= 7.0"
-  spec.add_dependency "actionview", ">= 7.0"
-  spec.add_dependency "activemodel", ">= 7.0"
-  spec.add_dependency "activerecord", ">= 7.0"
-  spec.add_dependency "activesupport", ">= 7.0"
+  %w[actionpack actionview activemodel activerecord activesupport].each do |rails_lib|
+    spec.add_runtime_dependency rails_lib, [">= 6.0.0", "< 8.0"]
+  end
 
   spec.add_dependency "citizens_advice_components"
 end

--- a/docs/testing-rails-versions.md
+++ b/docs/testing-rails-versions.md
@@ -1,0 +1,27 @@
+# Testing with different Rails versions
+
+We test the form builder in CI in the last three supported versions of Rails. In local development we default to Rails 7.1.
+
+You can test against different Rails versions locally by setting a `RAILS_VERSION` environment variable. First to install the new version:
+
+```sh
+RAILS_VERSION="~> 6.1.0" bundle install
+```
+
+Then to run the specs:
+
+```sh
+RAILS_VERSION="~> 6.1.0" bundle exec rspec
+```
+
+This will modify your `Gemfile.lock` so when you are done run:
+
+```sh
+git checkout -- Gemfile.lock
+```
+
+Followed by a fresh install:
+
+```sh
+bundle install
+```

--- a/lib/citizens_advice_form_builder/elements/base.rb
+++ b/lib/citizens_advice_form_builder/elements/base.rb
@@ -43,11 +43,23 @@ module CitizensAdviceFormBuilder
       end
 
       def field_name
-        template.field_name(object_name, attribute)
+        # We still support Rails 6.1 but rely on the use of field_name
+        # so we provide a shim for this method for older versions of Rails.
+        if Rails::VERSION::MAJOR < 7
+          field_name_shim(object_name, attribute)
+        else
+          template.field_name(object_name, attribute)
+        end
       end
 
       def field_id
-        template.field_id(object_name, attribute)
+        # We still support Rails 6.1 but rely on the use of field_id
+        # so we provide a shim for this method for older versions of Rails.
+        if Rails::VERSION::MAJOR < 7
+          field_id_shim(object_name, attribute)
+        else
+          template.field_id(object_name, attribute)
+        end
       end
 
       def label
@@ -74,6 +86,37 @@ module CitizensAdviceFormBuilder
 
       def form_field_classes
         class_names("cads-form-field", "cads-form-field--has-error": error?)
+      end
+
+      # https://github.com/rails/rails/blob/main/actionview/lib/action_view/helpers/form_tag_helper.rb#L102
+      def field_id_shim(object_name, method_name, *suffixes, index: nil, namespace: nil)
+        object_name = object_name.model_name.singular if object_name.respond_to?(:model_name)
+
+        sanitized_object_name = object_name.to_s.gsub(/\]\[|[^-a-zA-Z0-9:.]/, "_").delete_suffix("_")
+
+        sanitized_method_name = method_name.to_s.delete_suffix("?")
+
+        [
+          namespace,
+          sanitized_object_name.presence,
+          (index unless sanitized_object_name.empty?),
+          sanitized_method_name,
+          *suffixes
+        ].tap(&:compact!).join("_")
+      end
+
+      # https://github.com/rails/rails/blob/main/actionview/lib/action_view/helpers/form_tag_helper.rb#L132
+      def field_name_shim(object_name, method_name, *method_names, multiple: false, index: nil)
+        names = method_names.map! { |name| "[#{name}]" }.join
+
+        # a little duplication to construct fewer strings
+        if object_name.blank?
+          "#{method_name}#{names}#{multiple ? '[]' : ''}"
+        elsif index
+          "#{object_name}[#{index}][#{method_name}]#{names}#{multiple ? '[]' : ''}"
+        else
+          "#{object_name}[#{method_name}]#{names}#{multiple ? '[]' : ''}"
+        end
       end
     end
   end

--- a/lib/citizens_advice_form_builder/elements/date_input.rb
+++ b/lib/citizens_advice_form_builder/elements/date_input.rb
@@ -94,7 +94,13 @@ module CitizensAdviceFormBuilder
       end
 
       def date_field_name(suffix)
-        @template.field_name(object_name, "#{attribute}(#{suffix})")
+        # We still support Rails 6.1 but rely on the use of field_name
+        # so we provide a shim for this method for older versions of Rails.
+        if Rails::VERSION::MAJOR < 7
+          field_name_shim(object_name, "#{attribute}(#{suffix})")
+        else
+          @template.field_name(object_name, "#{attribute}(#{suffix})")
+        end
       end
 
       def date_field_id(suffix)

--- a/lib/citizens_advice_form_builder/elements/error_summary.rb
+++ b/lib/citizens_advice_form_builder/elements/error_summary.rb
@@ -22,7 +22,13 @@ module CitizensAdviceFormBuilder
       end
 
       def field_id_for(attribute)
-        @template.field_id(object_name, attribute)
+        # We still support Rails 6.1 but rely on the use of field_name
+        # so we provide a shim for this method for older versions of Rails.
+        if Rails::VERSION::MAJOR < 7
+          field_id_shim(object_name, attribute)
+        else
+          @template.field_id(object_name, attribute)
+        end
       end
     end
   end

--- a/spec/dummy/app/models/person.rb
+++ b/spec/dummy/app/models/person.rb
@@ -13,5 +13,15 @@ class Person
   attribute :pizza_toppings, array: true
 
   validates :first_name, presence: true
-  validates :date_of_birth, comparison: { less_than: Time.zone.today }
+
+  # Rails 7.1 provides a comparisson validator, but as we support Rails 6.1 use a simpler method as a check
+  # validates :date_of_birth, comparison: { less_than: Time.zone.today }
+  validates :date_of_birth, presence: true
+  validate :date_must_be_in_the_past
+
+  private
+
+  def date_must_be_in_the_past
+    errors.add(:date_of_birth, "can't be in the future!") if date_of_birth&.future?
+  end
 end

--- a/spec/dummy/config/application.rb
+++ b/spec/dummy/config/application.rb
@@ -23,12 +23,7 @@ Bundler.require(*Rails.groups)
 module Dummy
   class Application < Rails::Application
     # Initialize configuration defaults for originally generated Rails version.
-    # config.load_defaults 7.1
-
-    # Please, add to the `ignore` list any other `lib` subdirectories that do
-    # not contain `.rb` files, or that should not be reloaded or eager loaded.
-    # Common ones are `templates`, `generators`, or `middleware`, for example.
-    config.autoload_lib(ignore: %w[assets tasks])
+    config.load_defaults Rails.version.to_f
 
     # Configuration for the application, engines, and railties goes here.
     #

--- a/spec/dummy/config/environments/development.rb
+++ b/spec/dummy/config/environments/development.rb
@@ -52,7 +52,4 @@ Rails.application.configure do
 
   # Annotate rendered view with file names.
   # config.action_view.annotate_rendered_view_with_filenames = true
-
-  # Raise error when a before_action's only/except options reference missing actions
-  config.action_controller.raise_on_missing_callback_actions = true
 end

--- a/spec/dummy/config/environments/test.rb
+++ b/spec/dummy/config/environments/test.rb
@@ -50,7 +50,4 @@ Rails.application.configure do
 
   # Annotate rendered view with file names.
   # config.action_view.annotate_rendered_view_with_filenames = true
-
-  # Raise error when a before_action's only/except options reference missing actions
-  config.action_controller.raise_on_missing_callback_actions = true
 end


### PR DESCRIPTION
## Background

We have some projects running older Rails versions. The core design system engine supports the last three supported versions of Rails including Rails 6.1.

## Changes

Adds support for older versions by:

-  Increase the version range and update the CI workflow to allow testing against the same supported versions as the design system components themselves.
- Updating the library code to support older Rails versions (This requires providing a shim for our use of `field_id` and `field_name` which are only available in Rails 7+ but is otherwise already compatible)
- Updating the dummy spec application to use configuration available in all supported versions

I've also included a short document demonstrating how to test with older Rails versions locally. When we merge this code with the core design system engine we might want to revisit this approach to use something like [Appraisal](https://github.com/thoughtbot/appraisal) but this works for now.