### PR TITLE
fix: label for attribute

### DIFF
--- a/lib/citizens_advice_form_builder/elements/collections/check_boxes.rb
+++ b/lib/citizens_advice_form_builder/elements/collections/check_boxes.rb
@@ -44,7 +44,7 @@ module CitizensAdviceFormBuilder
                 value: item[:value],
                 checked: item[:checked]
               ) +
-                tag.label(class: "cads-form-group__label", for: "#{field_id}-#{index}") { item[:label] }
+                tag.label(class: "cads-form-group__label", for: item_id(index)) { item[:label] }
             end
           end
 

--- a/lib/citizens_advice_form_builder/elements/collections/radio_buttons.rb
+++ b/lib/citizens_advice_form_builder/elements/collections/radio_buttons.rb
@@ -44,7 +44,7 @@ module CitizensAdviceFormBuilder
                 value: item[:value],
                 checked: item[:checked]
               ) +
-                tag.label(class: "cads-form-group__label", for: "#{field_id}-#{index}") { item[:label] }
+                tag.label(class: "cads-form-group__label", for: item_id(index)) { item[:label] }
             end
           end
 

--- a/lib/citizens_advice_form_builder/elements/date_input.rb
+++ b/lib/citizens_advice_form_builder/elements/date_input.rb
@@ -51,7 +51,7 @@ module CitizensAdviceFormBuilder
       def day_input
         tag.div(class: "cads-date-input") do
           tag.div(class: "cads-date-input__item") do
-            tag.label(class: "cads-form-field__label", for: date_field_id("3i")) { "Day" } +
+            tag.label(class: "cads-form-field__label", for: "#{field_id}-input") { "Day" } +
               tag.input(
                 class: class_names("cads-input", "cads-input--2ch", "cads-input--error": error?),
                 name: date_field_name("3i"),

--- a/spec/features/date_input_spec.rb
+++ b/spec/features/date_input_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe "date inputs" do
   context "with the default date input" do
     it "renders the 'day' input field" do
       within "#default_date_input" do
-        expect(page).to have_css("label[for=person_date_of_birth_3i]", text: "Day")
+        expect(page).to have_css("label[for=person_date_of_birth-input]", text: "Day")
         expect(page).to have_field("person[date_of_birth(3i)]")
       end
     end


### PR DESCRIPTION
The input id of the first field of radio buttons, checkboxes and date inputs needed to be changed as part of the work to add error summary. This is because of the way error summary link urls are generated.
This PR ensures that the `label for` attribute matches the new input ids.