### PR TITLE
Bump citizens_advice_form_builder to 0.1.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [0.1.6] - 2024-07-05
+
+- Fix attribute name in error messages
+- Fix text input interface
+- Fix label "for" attribute in group fields
+- Add support for multiple Rails versions
+
 ## [0.1.5] - 2024-06-21
 
 - Add `cads_error_summary`

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -22,7 +22,7 @@ GIT
 PATH
   remote: .
   specs:
-    citizens_advice_form_builder (0.1.5)
+    citizens_advice_form_builder (0.1.6)
       actionpack (>= 6.0.0, < 8.0)
       actionview (>= 6.0.0, < 8.0)
       activemodel (>= 6.0.0, < 8.0)

--- a/lib/citizens_advice_form_builder/version.rb
+++ b/lib/citizens_advice_form_builder/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module CitizensAdviceFormBuilder
-  VERSION = "0.1.5"
+  VERSION = "0.1.6"
 end


### PR DESCRIPTION
- Fix attribute name in error messages
- Fix text input interface
- Fix label "for" attribute in group fields
- Add support for multiple Rails versions
