### PR TITLE
add single checkbox to the form builder

### DIFF
--- a/lib/citizens_advice_form_builder/elements.rb
+++ b/lib/citizens_advice_form_builder/elements.rb
@@ -6,6 +6,7 @@ require_relative "elements/button"
 require_relative "elements/text_area"
 require_relative "elements/date_input"
 require_relative "elements/error_summary"
+require_relative "elements/check_box"
 
 require_relative "elements/collections/base"
 require_relative "elements/collections/radio_buttons"

--- a/lib/citizens_advice_form_builder/elements/check_box.rb
+++ b/lib/citizens_advice_form_builder/elements/check_box.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+module CitizensAdviceFormBuilder
+  module Elements
+    class CheckBox < Base
+      def render
+        safe_join([hidden_field, checkbox_field])
+      end
+
+      private
+
+      def checkbox_field
+        component = CitizensAdviceComponents::CheckboxSingle.new(
+          name: field_name,
+          id: field_id,
+          error_message: error_message
+        )
+        component.with_checkbox(label: label,
+                                value: "1",
+                                checked: current_value,
+                                additional_attributes: options[:additional_attributes])
+
+        component.render_in(@template)
+      end
+
+      def hidden_field
+        tag.input(
+          type: "hidden",
+          name: field_name,
+          value: "0"
+        )
+      end
+    end
+  end
+end

--- a/lib/citizens_advice_form_builder/form_builder.rb
+++ b/lib/citizens_advice_form_builder/form_builder.rb
@@ -13,7 +13,9 @@ require CitizensAdviceComponents::Engine.root.join("app", "components", "citizen
 require CitizensAdviceComponents::Engine.root.join("app", "components", "citizens_advice_components", "textarea")
 require CitizensAdviceComponents::Engine.root.join("app", "components", "citizens_advice_components", "form_group")
 require CitizensAdviceComponents::Engine.root.join("app", "components", "citizens_advice_components", "checkable", "base")
+require CitizensAdviceComponents::Engine.root.join("app", "components", "citizens_advice_components", "checkable", "checkbox")
 require CitizensAdviceComponents::Engine.root.join("app", "components", "citizens_advice_components", "checkable", "radio")
+require CitizensAdviceComponents::Engine.root.join("app", "components", "citizens_advice_components", "checkbox_single")
 require CitizensAdviceComponents::Engine.root.join("app", "components", "citizens_advice_components", "radio_group")
 require CitizensAdviceComponents::Engine.root.join("app", "components", "citizens_advice_components", "error_summary")
 
@@ -49,6 +51,10 @@ module CitizensAdviceFormBuilder
 
     def cads_error_summary
       Elements::ErrorSummary.new(@template, object, :unused).render
+    end
+
+    def cads_check_box(attribute, label: nil, **kwargs)
+      Elements::CheckBox.new(@template, object, attribute, label: label, **kwargs).render
     end
   end
 end

--- a/spec/dummy/app/models/person.rb
+++ b/spec/dummy/app/models/person.rb
@@ -11,6 +11,8 @@ class Person
 
   attribute :date_of_birth, :date
   attribute :pizza_toppings, array: true
+  attribute :opted_in, :boolean
+  attribute :account_active, :boolean, default: true
 
   validates :first_name, presence: true
 

--- a/spec/dummy/app/views/elements/check_box.html.erb
+++ b/spec/dummy/app/views/elements/check_box.html.erb
@@ -1,0 +1,9 @@
+<%= form_with model: @person, url: request.path do |f| %>
+  <div id="default_check_box">
+    <%= f.cads_check_box :opted_in, label: "Opted in" %>
+  </div>
+
+  <div id="checked_check_box">
+    <%= f.cads_check_box :account_active, label: "Account active" %>
+  </div>
+<% end %>

--- a/spec/features/check_box_spec.rb
+++ b/spec/features/check_box_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "single check boxes" do
+  before do
+    visit element_path("check_box")
+  end
+
+  it "renders the visible unchecked checkbox" do
+    expect(page).to have_unchecked_field("person[opted_in]", type: "checkbox", with: "1")
+  end
+
+  it "renders the label" do
+    expect(page).to have_text("Opted in")
+  end
+
+  it "renders the hidden field which defaults to false" do
+    expect(page).to have_field("person[opted_in]", type: "hidden", with: "0")
+  end
+
+  it "renders the visible checked checkbox" do
+    expect(page).to have_checked_field("person[account_active]", type: "checkbox", with: "1")
+  end
+end


### PR DESCRIPTION
This is used to e.g., record consent for processing special purpose data