### PR TITLE
Bump citizens_advice_form_builder to 0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [0.2.0] - 2024-09-10
+
+- **BREAKING CHANGE**: Drop support for Rails 6.0, requires 6.1 or later now
+- Add `cads_check_box` for single checkboxes/boolean attributes
+
 ## [0.1.6] - 2024-07-05
 
 - Fix attribute name in error messages

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -22,12 +22,12 @@ GIT
 PATH
   remote: .
   specs:
-    citizens_advice_form_builder (0.1.6)
-      actionpack (>= 6.0.0, < 8.0)
-      actionview (>= 6.0.0, < 8.0)
-      activemodel (>= 6.0.0, < 8.0)
-      activerecord (>= 6.0.0, < 8.0)
-      activesupport (>= 6.0.0, < 8.0)
+    citizens_advice_form_builder (0.2.0)
+      actionpack (>= 6.1.0, < 8.0)
+      actionview (>= 6.1.0, < 8.0)
+      activemodel (>= 6.1.0, < 8.0)
+      activerecord (>= 6.1.0, < 8.0)
+      activesupport (>= 6.1.0, < 8.0)
       citizens_advice_components
 
 GEM

--- a/lib/citizens_advice_form_builder/version.rb
+++ b/lib/citizens_advice_form_builder/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module CitizensAdviceFormBuilder
-  VERSION = "0.1.6"
+  VERSION = "0.2.0"
 end


### PR DESCRIPTION
this is a minor version bump to match semver as there is a breaking change (in practice we should consider releasing 1.0.0)

full diff: https://github.com/citizensadvice/rails-form-builder/compare/v0.1.6...v0.2.0