### PR TITLE
Add archive notice to the project

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,24 +1,6 @@
 # Citizens Advice Form Builder
 
-[![Continuous Integration](https://github.com/citizensadvice/rails-form-builder/actions/workflows/main.yml/badge.svg?event=push)](https://github.com/citizensadvice/rails-form-builder/actions/workflows/main.yml)
-
-## Installation
-
-Install the gem and add to the application's Gemfile by executing:
-
-    $ bundle add citizens_advice_form_builder
-
-If bundler is not being used to manage dependencies, install the gem by executing:
-
-    $ gem install citizens_advice_form_builder
-
-## Usage
-
-This gem provides a custom Rails form builder which provides a Rails-like
-interface for generating forms using the Citizens Advice design system component
-library.
-
-## Release process
-
-Instructions can be found in [RELEASE.md](RELEASE.md).
-
+> [!NOTE]
+> As of v7.0.0 the rails form builder is now included as part of the main Design System
+>
+> Please use https://github.com/citizensadvice/design-system


### PR DESCRIPTION
Redirect people over to the main design system project now that it includes the form builder code. Only merge once projects have migrated away.